### PR TITLE
Add sync_project_bugs and days options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ JIRA API token can be created here https://id.atlassian.com/manage-profile/secur
 
 ## Usage:
 ```
-usage: lp-to-jira [options] bug-id project-id
+Usage: lp-to-jira [options] bug-id project-id
 
 Create JIRA entry for a given Launchpad bug ID
 
@@ -22,11 +22,18 @@ options:
                 print the JIRA issue ID if found
     -l, --label LABEL
                 Add LABEL to the JIRA issue after creation
+    -s SYNC_PROJECT_BUGS, --sync_project_bugs=SYNC_PROJECT_BUGS
+                The name of the LP Project. This will bring in every
+                bug from your project if you do not also specify days
+    -d DAYS, --days=DAYS
+                Only look for LP Bugs in the past n days
+    --no-lp-tag
 
 Examples:
     lp-to-jira 3215487 FR
     lp-to-jira -e 3215487 FR
     lp-to-jira -l ubuntu-meeting 3215487 PR
+    lp-to-jira -s ubuntu -d 3 IQA
 ```
 
 # lp-to-jira-report

--- a/lp-to-jira
+++ b/lp-to-jira
@@ -8,12 +8,14 @@ import os
 import json
 
 from optparse import OptionParser
+from datetime import datetime, timedelta
 
 from launchpadlib.launchpad import Launchpad
 from jira import JIRA
 from jira_api import jira_api
 
 
+# TODO: paramaterize this, for now we just hardcode
 pkg_to_component = {
     "nplan": "netplan",
     "netplan.io": "netplan",
@@ -27,7 +29,9 @@ pkg_to_component = {
     "openjdk-lts": "OpenJDK",
     "apt": "Package Management",
     "aptdaemon": "Package Management",
-    "ubuntu-release-upgrader": "Package Management"
+    "ubuntu-release-upgrader": "Package Management",
+    "solutions-qa-ci": "Solutions QA CI",
+    "cpe-foundation": "FCE",
 }
 default_component = "Distro"
 
@@ -57,6 +61,35 @@ def getLpBugPkg(lp, bug):
                 bug_pkg = task.bug_target_name.split()[0]
 
     return bug_pkg
+
+
+def getAllLpProjectBugs(lp, project, days=None):
+    """Return iterable IBugTasks of all Bugs in a Project filed in the past n
+    days. If days is not specified, return all Bugs."""
+
+    project = lp.projects[project]
+    created_since = None
+
+    if days:
+        created_since = datetime.now() - timedelta(days)
+        created_since = created_since.strftime('%Y-%m-%d')
+
+    bugs = project.searchTasks(
+        created_since=created_since,
+        status=[
+            'New',
+            'Incomplete',
+            'Triaged',
+            'Opinion',
+            'Invalid',
+            'Won\'t Fix',
+            'Confirmed',
+            'In Progress',
+            'Fix Committed',
+            'Fix Released'
+        ])
+
+    return bugs
 
 
 def isBugInJira(jira, bug, project_id):
@@ -143,11 +176,18 @@ options:
                 print the JIRA issue ID if found
     -l, --label LABEL
                 Add LABEL to the JIRA issue after creation
+    -s SYNC_PROJECT_BUGS, --sync_project_bugs=SYNC_PROJECT_BUGS
+                The name of the LP Project. This will bring in every
+                bug from your project if you do not also specify days
+    -d DAYS, --days=DAYS
+                Only look for LP Bugs in the past n days
+    --no-lp-tag
 
 Examples:
     lp-to-jira 3215487 FR
     lp-to-jira -e 3215487 FR
     lp-to-jira -l ubuntu-meeting 3215487 PR
+    lp-to-jira -s ubuntu -d 3 IQA
         """
 
     opt_parser = OptionParser(usage)
@@ -162,9 +202,28 @@ Examples:
     )
 
     opt_parser.add_option(
+        '-s', '--sync_project_bugs',
+        dest='sync_project_bugs',
+        action='store',
+        type=str,
+        help='Adds all bugs from a specified LP Project to specified Jira board'
+            ' if they are not already on the Jira board.'
+            ' Use --days to narrow down bugs'
+    )
+
+    opt_parser.add_option(
+        '-d', '--days',
+        dest='days',
+        action='store',
+        type=int,
+        help='Only look for LP Bugs in the past n days'
+    )
+
+    opt_parser.add_option(
         '--no-lp-tag',
         dest='no_lp_tag',
-        action='store_true'
+        action='store_true',
+        help='Do not add tag to LP Bug'
     )
 
     opts, args = opt_parser.parse_args()
@@ -176,6 +235,16 @@ Examples:
     # Connect to the JIRA API
     api = jira_api()
     jira = JIRA(api.server, basic_auth=(api.login, api.token))
+
+    if opts.sync_project_bugs:
+        bugs_list = getAllLpProjectBugs(lp, opts.sync_project_bugs, opts.days)
+
+        for bug in bugs_list:
+            bug_number = bug.bug_link.split('/')[-1]
+            print(bug_number)
+            # bug = getLpBug(lp, bug_number)
+            # lpToJiraBug(lp, jira, bug, args[0], opts)
+        return 0
 
     # Make sure there's 2 arguments
     if len(args) < 2:

--- a/lp-to-jira
+++ b/lp-to-jira
@@ -32,6 +32,105 @@ pkg_to_component = {
 default_component = "Distro"
 
 
+def getLpBug(lp, bug_number):
+    """Make sure the bug ID exists, return bug"""
+
+    bug = None
+    try:
+        bug = lp.bugs[bug_number]
+    except Exception:
+        print("Couldn't find the Launchpad bug {}".format(bug_number))
+        sys.exit(1)
+
+    return bug
+
+
+def getLpBugPkg(lp, bug):
+    """From a LP bug, get its package"""
+
+    bug_pkg = None
+    if len(bug.bug_tasks) == 1:
+        bug_pkg = bug.bug_tasks[0].bug_target_name.split()[0]
+    else:
+        for task in bug.bug_tasks:
+            if "(Ubuntu)" in task.bug_target_name:
+                bug_pkg = task.bug_target_name.split()[0]
+
+    return bug_pkg
+
+
+def isBugInJira(jira, bug, project_id):
+    """Checks Jira for the same ID as the Bug you're trying to import"""
+
+    existing_issue = jira.search_issues(
+        "project = \"{}\" AND summary ~ \"LP#{}\"".format(project_id, bug.id))
+
+    if existing_issue:
+        print("Launchpad Issue {} is already logged "
+              "in JIRA here {}/browse/{}".format(
+                  bug.id,
+                  jira.client_info(),
+                  existing_issue[0].key))
+        return True
+    return False
+
+
+def buildJiraIssue(lp, bug, project_id):
+    """Builds and return a dict to create a Jira Issue from"""
+
+    # Get bug info from LP
+    bug_pkg = getLpBugPkg(lp, bug)
+
+    # Build the Jira Issue from the LP info
+    issue_dict = {
+        'project': project_id,
+        'summary': 'LP#{} [{}] {}'.format(bug.id, bug_pkg, bug.title),
+        'description': bug.description,
+        'issuetype': {'name': 'Bug'}
+    }
+
+    jira_component = []
+    jira_component.append(
+        {"name":pkg_to_component.get(bug_pkg, default_component)})
+    issue_dict["components"] = jira_component
+    
+    return issue_dict
+
+
+def createJiraIssue(jira, issue_dict, bug):
+    """Create and return a Jira Issue from issue_dict"""
+
+    # Import the bug and return the JIRA ID for said bug
+    new_issue = jira.create_issue(fields=issue_dict)
+
+    # Adding a link to the Launchpad bug into the JIRA entry
+    link = {'url': bug.web_link, 'title': 'Launchpad Link'}
+    jira.add_simple_link(new_issue, object=link)
+
+    print("Created {}/browse/{}".format(jira.client_info(), new_issue.key))
+
+    return new_issue
+
+
+def lpToJiraBug(lp, jira, bug, project_id, opts):
+    """Create JIRA issue at project_id for a given Launchpad bug"""
+    
+    if isBugInJira(jira, bug, project_id):
+        return
+    
+    issue_dict = buildJiraIssue(lp, bug, project_id)
+    if opts.label:
+        # Add labels if specified
+        issue_dict["labels"] = [opts.label]
+
+    jira_issue = createJiraIssue(jira, issue_dict, bug)
+
+    if not opts.no_lp_tag:
+        # Add reference to the JIRA entry in the bugs on Launchpad
+        bug.tags += [jira_issue.key.lower()]
+        bug.lp_save()
+
+
 def main():
     usage = """\
 usage: lp-to-jira [options] bug-id project-id
@@ -62,7 +161,21 @@ Examples:
         action='store_true'
     )
 
+    opt_parser.add_option(
+        '--no-lp-tag',
+        dest='no_lp_tag',
+        action='store_true'
+    )
+
     opts, args = opt_parser.parse_args()
+
+    # Connect to Launchpad API
+    # TODO: catch exception if the Launchpad API isn't open
+    lp = Launchpad.login_with('foundations', 'production', version='devel')
+
+    # Connect to the JIRA API
+    api = jira_api()
+    jira = JIRA(api.server, basic_auth=(api.login, api.token))
 
     # Make sure there's 2 arguments
     if len(args) < 2:
@@ -71,86 +184,18 @@ Examples:
 
     bug_number = args[0]
     project_id = args[1]
-
-    jira_token_file = "{}/.jira.token".format(os.path.expanduser('~'))
-
-    # 1. Connect to Launchpad API
-
-    # TODO: catch exception if the Launchpad API isn't open
-    lp = Launchpad.login_with('foundations', 'production', version='devel')
-
-    # 2. Make sure the bug ID exist
-    bug = None
-    bug_pkg = None
-    try:
-        bug = lp.bugs[bug_number]
-    except Exception:
-        print("Couldn't find the Launchpad bug {}".format(bug_number))
-        return 1
-
-    if len(bug.bug_tasks) == 1:
-        bug_pkg = bug.bug_tasks[0].bug_target_name.split()[0]
-    else:
-        for task in bug.bug_tasks:
-            if "(Ubuntu)" in task.bug_target_name:
-                bug_pkg = task.bug_target_name.split()[0]
-
-    # 3. Connect to the JIRA API
-    api = jira_api()
-    jira = JIRA(api.server, basic_auth=(api.login, api.token))
-
-    # 4. Make sure that there's no bug in JIRA with the same ID
-    # than the Bug you're trying to import
-    existing_issue = jira.search_issues(
-        "project = \"{}\" AND summary ~ \"LP#{}\"".format(project_id, bug.id))
-
-    if existing_issue:
-        print("Launchpad Issue {} is already logged "
-              "in JIRA here {}/browse/{}".format(
-                  bug_number,
-                  api.server,
-                  existing_issue[0].key))
-
-        if opts.exists:
-            # we are simply testing if the bug was already in JIRA
-            # if it was we return 0
-            return 0
-
-        # However here the intent was to create a bug which already exists
-        # So we return 1 instead
-        return 1
+    bug = getLpBug(lp, bug_number)
 
     if opts.exists:
+        # We are simply testing if the bug was already in JIRA
+        if isBugInJira(jira, bug, project_id):
+            return 0
         print("Launchpad Issue {} is not in JIRA project {}".format(
-            bug_number, project_id))
+            bug.id, project_id))
         return 1
 
-    issue_dict = {
-        'project': project_id,
-        'summary': 'LP#{} [{}] {}'.format(bug.id, bug_pkg, bug.title),
-        'description': bug.description,
-        'issuetype': {'name': 'Bug'}
-    }
-    if opts.label:
-        issue_dict["labels"] = [opts.label]
-
-    jira_component = []
-    jira_component.append(
-        {"name":pkg_to_component.get(bug_pkg, default_component)})
-    issue_dict["components"] = jira_component
-
-    # 5. import the bug and return the JIRA ID for said bug
-    new_issue = jira.create_issue(fields=issue_dict)
-
-    # 6. Adding a link to the Launchpad bug into the JIRA entry
-    link = {'url': bug.web_link, 'title': 'Launchpad Link'}
-    jira.add_simple_link(new_issue, object=link)
-
-    # 7. Add reference to the JIRA entry in the bugs on Launchpad
-    bug.tags += [new_issue.key.lower()]
-    bug.lp_save()
-
-    print("Created {}/browse/{}".format(api.server, new_issue.key))
+    # Create the Jira Issue
+    lpToJiraBug(lp, jira, bug, project_id, opts)
 
     return 0
 

--- a/lp-to-jira
+++ b/lp-to-jira
@@ -36,7 +36,7 @@ pkg_to_component = {
 default_component = "Distro"
 
 
-def getLpBug(lp, bug_number):
+def get_lp_bug(lp, bug_number):
     """Make sure the bug ID exists, return bug"""
 
     bug = None
@@ -49,7 +49,7 @@ def getLpBug(lp, bug_number):
     return bug
 
 
-def getLpBugPkg(lp, bug):
+def get_lp_bug_pkg(lp, bug):
     """From a LP bug, get its package"""
 
     bug_pkg = None
@@ -63,18 +63,22 @@ def getLpBugPkg(lp, bug):
     return bug_pkg
 
 
-def getAllLpProjectBugs(lp, project, days=None):
+def get_all_lp_project_bugs(lp, project, days=None):
     """Return iterable IBugTasks of all Bugs in a Project filed in the past n
     days. If days is not specified, return all Bugs."""
 
-    project = lp.projects[project]
+    try:
+        lp_project = lp.projects[project]
+    except KeyError:
+        print("Couldn't find the Launchpad project \"{}\"".format(project))
+        sys.exit(1)
+
     created_since = None
 
     if days:
-        created_since = datetime.now() - timedelta(days)
-        created_since = created_since.strftime('%Y-%m-%d')
+        created_since = (datetime.now() - timedelta(days)).strftime('%Y-%m-%d')
 
-    bugs = project.searchTasks(
+    bugs = lp_project.searchTasks(
         created_since=created_since,
         status=[
             'New',
@@ -92,7 +96,7 @@ def getAllLpProjectBugs(lp, project, days=None):
     return bugs
 
 
-def isBugInJira(jira, bug, project_id):
+def is_bug_in_jira(jira, bug, project_id):
     """Checks Jira for the same ID as the Bug you're trying to import"""
 
     existing_issue = jira.search_issues(
@@ -108,11 +112,11 @@ def isBugInJira(jira, bug, project_id):
     return False
 
 
-def buildJiraIssue(lp, bug, project_id):
+def build_jira_issue(lp, bug, project_id):
     """Builds and return a dict to create a Jira Issue from"""
 
     # Get bug info from LP
-    bug_pkg = getLpBugPkg(lp, bug)
+    bug_pkg = get_lp_bug_pkg(lp, bug)
 
     # Build the Jira Issue from the LP info
     issue_dict = {
@@ -130,7 +134,7 @@ def buildJiraIssue(lp, bug, project_id):
     return issue_dict
 
 
-def createJiraIssue(jira, issue_dict, bug):
+def create_jira_issue(jira, issue_dict, bug):
     """Create and return a Jira Issue from issue_dict"""
 
     # Import the bug and return the JIRA ID for said bug
@@ -145,18 +149,18 @@ def createJiraIssue(jira, issue_dict, bug):
     return new_issue
 
 
-def lpToJiraBug(lp, jira, bug, project_id, opts):
+def lp_to_jira_bug(lp, jira, bug, project_id, opts):
     """Create JIRA issue at project_id for a given Launchpad bug"""
     
-    if isBugInJira(jira, bug, project_id):
+    if is_bug_in_jira(jira, bug, project_id):
         return
     
-    issue_dict = buildJiraIssue(lp, bug, project_id)
+    issue_dict = build_jira_issue(lp, bug, project_id)
     if opts.label:
         # Add labels if specified
         issue_dict["labels"] = [opts.label]
 
-    jira_issue = createJiraIssue(jira, issue_dict, bug)
+    jira_issue = create_jira_issue(jira, issue_dict, bug)
 
     if not opts.no_lp_tag:
         # Add reference to the JIRA entry in the bugs on Launchpad
@@ -237,13 +241,12 @@ Examples:
     jira = JIRA(api.server, basic_auth=(api.login, api.token))
 
     if opts.sync_project_bugs:
-        bugs_list = getAllLpProjectBugs(lp, opts.sync_project_bugs, opts.days)
+        bugs_list = get_all_lp_project_bugs(lp, opts.sync_project_bugs, opts.days)
 
         for bug in bugs_list:
             bug_number = bug.bug_link.split('/')[-1]
-            print(bug_number)
-            # bug = getLpBug(lp, bug_number)
-            # lpToJiraBug(lp, jira, bug, args[0], opts)
+            bug = get_lp_bug(lp, bug_number)
+            lp_to_jira_bug(lp, jira, bug, args[0], opts)
         return 0
 
     # Make sure there's 2 arguments
@@ -253,18 +256,18 @@ Examples:
 
     bug_number = args[0]
     project_id = args[1]
-    bug = getLpBug(lp, bug_number)
+    bug = get_lp_bug(lp, bug_number)
 
     if opts.exists:
         # We are simply testing if the bug was already in JIRA
-        if isBugInJira(jira, bug, project_id):
+        if is_bug_in_jira(jira, bug, project_id):
             return 0
         print("Launchpad Issue {} is not in JIRA project {}".format(
             bug.id, project_id))
         return 1
 
     # Create the Jira Issue
-    lpToJiraBug(lp, jira, bug, project_id, opts)
+    lp_to_jira_bug(lp, jira, bug, project_id, opts)
 
     return 0
 


### PR DESCRIPTION
`sync_project_bugs` takes the name of a LP Project and adds every bug from
the specified project. `sync_project_bugs` may be used with the days
option to only look for bugs in a project in the past n days.

This PR also refactors the LP to Jira bug interactions.
All the functionality and APIs are the exact same. This change just
makes it a bit easier to extend the code for wider usage.