### PR TITLE
Save credential and token in snap common when in a snap context

### DIFF
--- a/LpToJira/jira_api.py
+++ b/LpToJira/jira_api.py
@@ -8,8 +8,12 @@ import json
 from jira import JIRA
 
 class jira_api():
-    def __init__(self,credstore="{}/.jira.token".format(os.getenv("SNAP_USER_COMMON"))):
-        self.credstore = credstore
+    def __init__(self,credstore="{}/.jira.token".format(os.path.expanduser('~'))):
+        snap_home = os.getenv("SNAP_USER_COMMON")
+        if snap_home:
+            self.credstore = "{}/.jira.token".format(snap_home)
+        else:
+            self.credstore = credstore
         try:
             with open(self.credstore) as f:
                 config = json.load(f)

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -133,7 +133,7 @@ def build_jira_issue(lp, bug, project_id):
     jira_component.append(
         {"name":pkg_to_component.get(bug_pkg, default_component)})
     issue_dict["components"] = jira_component
-    
+
     return issue_dict
 
 
@@ -154,10 +154,10 @@ def create_jira_issue(jira, issue_dict, bug):
 
 def lp_to_jira_bug(lp, jira, bug, project_id, opts):
     """Create JIRA issue at project_id for a given Launchpad bug"""
-    
+
     if is_bug_in_jira(jira, bug, project_id):
         return
-    
+
     issue_dict = build_jira_issue(lp, bug, project_id)
     if opts.label:
         # Add labels if specified
@@ -237,7 +237,11 @@ Examples:
 
     # Connect to Launchpad API
     # TODO: catch exception if the Launchpad API isn't open
-    credential_store = UnencryptedFileCredentialStore(os.path.expanduser("~/.lp_creds"))
+    snap_home = os.getenv("SNAP_USER_COMMON")
+    if snap_home:
+        credential_store = UnencryptedFileCredentialStore("{}/.lp_creds".format(snap_home))
+    else:
+        credential_store = UnencryptedFileCredentialStore(os.path.expanduser("~/.lp_creds"))
     lp = Launchpad.login_with(
         'foundations',
         'production',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="LpToJira",
-    version="0.5",
+    version="0.6",
     author="Matthieu Clemenceau",
     author_email="matthieu.clemenceau@canonical.com",
     description=("A Command Line helper to import launchpad bug in JIRA."),

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: lp-to-jira
 base: core20
-version: '0.5'
+version: '0.6'
 summary: Command Line Interface to import Launchpad content into JIRA
 description: |
   lp-to-jira allows you to import bug from a launchpad project into a JIRA


### PR DESCRIPTION
Save JIRA token and LP Credential in snap/lp-to-jira/common in order to keep cached credentials from one snap to another.