### PR TITLE
Return a package name for any bug

### DIFF
--- a/LpToJira/lp_bug.py
+++ b/LpToJira/lp_bug.py
@@ -2,10 +2,11 @@
 # Simple LaunchPad Bug object used to store some informations from LaunchPad
 # into a structure that can be stored in and out of a json file
 
-ubuntu_devel = 'Jammy'
+ubuntu_devel = 'Karmic'
 
 ubuntu_version = {
-    ubuntu_devel: '22.04',
+    ubuntu_devel: '22.10',
+    'Jammy': '22.04',
     'Impish': '21.10',
     'Hirsute': '21.04',
     'Groovy': '20.10',
@@ -41,31 +42,36 @@ class lp_bug():
             task_name = task.bug_target_name
             if " (Ubuntu" in task_name:
                 package_name = task_name.split()[0]
+            else:
+                package_name = task_name
 
-                if package_name not in self.packages_info.keys():
-                    self.packages_info[package_name] = {}
+            if package_name not in self.packages_info.keys():
+                self.packages_info[package_name] = {}
 
-                # Grab the Ubuntu serie our of the task name
-                # Set the serie to ubuntu_devel is empty
+            # Grab the Ubuntu serie our of the task name
+            # Set the serie to ubuntu_devel is empty
+            try:
                 serie = task_name[task_name.index("Ubuntu")+7:-1]
-                if serie == '':
-                    serie = ubuntu_devel
-                elif serie not in ubuntu_version.keys():
-                    continue
+            except:
+                serie = ''
+            if serie == '':
+                serie = ubuntu_devel
+            elif serie not in ubuntu_version.keys():
+                continue
 
-                if "series" not in self.packages_info[package_name].keys():
-                    self.packages_info[package_name]["series"] = {}
+            if "series" not in self.packages_info[package_name].keys():
+                self.packages_info[package_name]["series"] = {}
 
-                if serie not in self.packages_info[package_name]["series"].keys():
-                    self.packages_info[package_name]["series"][serie] = {}
+            if serie not in self.packages_info[package_name]["series"].keys():
+                self.packages_info[package_name]["series"][serie] = {}
 
-                # For each impacted package/serie, capture status
-                self.packages_info[package_name]["series"][serie]["status"]\
-                    = task.status
+            # For each impacted package/serie, capture status
+            self.packages_info[package_name]["series"][serie]["status"]\
+                = task.status
 
-                # For each impacted package/serie, capture importance
-                self.packages_info[package_name]["series"][serie]["importance"]\
-                    = task.importance
+            # For each impacted package/serie, capture importance
+            self.packages_info[package_name]["series"][serie]["importance"]\
+                = task.importance
 
     @property
     def affected_packages(self):

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -65,11 +65,13 @@ def get_lp_bug_pkg(bug):
 
     bug_pkg = None
 
-    # Only return bug from Ubuntu (will return the last one if multiple pkgs
+    # Be sure to return a package name. (returns the last one found if more
+    # than one package has been added)
     for task in bug.bug_tasks:
         if "(Ubuntu" in task.bug_target_name:
             bug_pkg = task.bug_target_name.split()[0]
-
+        else:
+            bug_pkg = task.bug_target_name
     return bug_pkg
 
 

--- a/LpToJira/lp_to_jira_report.py
+++ b/LpToJira/lp_to_jira_report.py
@@ -26,6 +26,7 @@ jira = None
 api = None
 
 series = ["Devel",
+          "Jammy",
           "Impish",
           "Hirsute",
           "Focal",
@@ -366,6 +367,7 @@ def find_issues_in_project(api, project):
                 'Importance': '',
                 'Packages': '',
                 "Devel": '',
+                "Jammy": '',
                 "Impish": '',
                 "Hirsute": '',
                 "Focal": '',
@@ -473,6 +475,7 @@ def merge_lp_data_with_jira_issues(jira, lp, issues, sync=False):
         print("#", flush=True, end='')
         lpbug_importance = ""
         lpbug_devel = ""
+        lpbug_jammy = ""
         lpbug_impish = ""
         lpbug_hirsute = ""
         lpbug_focal = ""
@@ -501,6 +504,8 @@ def merge_lp_data_with_jira_issues(jira, lp, issues, sync=False):
 
                     lpbug_devel = lpbug.package_detail(
                         pkg, ubuntu_devel, "status")
+                    lpbug_jammy = lpbug.package_detail(
+                        pkg, "Jammy", "status") 
                     lpbug_impish = lpbug.package_detail(
                         pkg, "Impish", "status")
                     lpbug_hirsute = lpbug.package_detail(
@@ -518,6 +523,7 @@ def merge_lp_data_with_jira_issues(jira, lp, issues, sync=False):
             issue['Importance'] = lpbug_importance
             issue['Packages'] = pkg
             issue["Devel"] = lpbug_devel
+            issue["Jammy"] = lpbug_jammy
             issue["Impish"] = lpbug_impish
             issue["Hirsute"] = lpbug_hirsute
             issue["Focal"] = lpbug_focal

--- a/LpToJira/lp_to_jira_sync.py
+++ b/LpToJira/lp_to_jira_sync.py
@@ -20,7 +20,7 @@ jira_project = ""
 db_json = "lp_to_jira_db.json"
 
 def get_bug_id(summary):
-    "Extract the bug id from a jira title whivh would icnlude LP#"
+    "Extract the bug id from a jira title which would include LP#"
     id = ""
 
     if "LP#" in summary:


### PR DESCRIPTION
Returns a package name regardless of whether the bug is filed against an Ubuntu package or not. Fixes a problem where non-Ubuntu packages get jira card titles like this:

LP:#12345 [None] SUMMARY 

which is a bit annoying when you are tracking bugs across multiple packages that are not hosted in the Ubuntu repositories (such as the various checkbox packages we use in Cert).

As an aside, I debated changing this so that Ubuntu packages get a reformatted pkg_name like this:

UBUNTU/package_name

to distinguish against cases where users can file bugs against both a source and an ubuntu source for same package... such as with some Main packages such as:

https://bugs.launchpad.net/apport
vs
https://bugs.launchpad.net/ubuntu/+source/apport

but I decided against that to preserve the original functionality of just stripping (Ubuntu) from pkg_name.