### PR TITLE
Add package(s) affected by bug in title

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = LpToJira
-version = 0.7
+version = 0.8
 description = A Command Line helper to import launchpad bug in JIRA.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: lp-to-jira
 base: core20
-version: '0.7'
+version: '0.8'
 summary: Command Line Interface to import Launchpad content into JIRA
 description: |
   lp-to-jira allows you to import bug from a launchpad project into a JIRA


### PR DESCRIPTION
Previous versions of the tool looked for packages part of "(Ubuntu" and
added the name of the last one found in the title of the JIRA bug issue.
This change adds all the packages affected as "[labels]". No components
are marked as affected (except if "-c component" is passed).