### PR TITLE
Add favicon for the LaunchPad weblink and support attaching JIRA link in LP description.

### DIFF
--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -184,9 +184,9 @@ def lp_to_jira_bug(lp, jira, bug, project_id, opts):
 
     jira_issue = create_jira_issue(jira, issue_dict, bug, opts)
 
-    if not opts.no_lp_tag:
+    if not opts.no_lp_link:
         # Add reference to the JIRA entry in the bugs on Launchpad
-        bug.tags += [jira_issue.key.lower()]
+        bug.description += '\n\n---\nExternal link: https://warthogs.atlassian.net/browse/'+jira_issue.key
         bug.lp_save()
 
 
@@ -200,7 +200,7 @@ def main(args=None):
             lp-to-jira -e 3215487 FR
             lp-to-jira -l ubuntu-meeting 3215487 PR
             lp-to-jira -s ubuntu -d 3 IQA
-            lp-to-jira --no-lp-tag -c Network -E FS-543 123231 PR
+            lp-to-jira --no-lp-link -c Network -E FS-543 123231 PR
             lp-to-jira -s ubuntu -t go-to-jira PR
             lp-to-jira -s ubuntu -t go-to-jira -t also-to-jira PR
             lp-to-jira -s ubuntu -t=-ignore-these PR
@@ -269,10 +269,10 @@ def main(args=None):
             ''')
     )
     opt_parser.add_argument(
-        '--no-lp-tag',
-        dest='no_lp_tag',
+        '--no-lp-link',
+        dest='no_lp_link',
         action='store_true',
-        help='Do not add tag to LP Bug'
+        help='Do not add link in description to LP Bug'
     )
 
     opts = opt_parser.parse_args(args)

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -156,7 +156,7 @@ def create_jira_issue(jira, issue_dict, bug, opts=None):
     new_issue = jira.create_issue(fields=issue_dict)
 
     # Adding a link to the Launchpad bug into the JIRA entry
-    link = {'url': bug.web_link, 'title': 'Launchpad Link'}
+    link = {'url': bug.web_link, 'title': 'Launchpad Link', 'icon': {'url16x16': 'https://bugs.launchpad.net/favicon.ico'}}
     jira.add_simple_link(new_issue, object=link)
 
     print("Created {}/browse/{}".format(jira.client_info(), new_issue.key))

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -184,11 +184,15 @@ def lp_to_jira_bug(lp, jira, bug, project_id, opts):
 
     jira_issue = create_jira_issue(jira, issue_dict, bug, opts)
 
-    if not opts.no_lp_link:
+    if opts.lp_link:
         # Add reference to the JIRA entry in the bugs on Launchpad
         bug.description += '\n\n---\nExternal link: https://warthogs.atlassian.net/browse/'+jira_issue.key
         bug.lp_save()
 
+    if opts.lp_tag:
+        # Add reference to the JIRA entry in the bugs on Launchpad
+        bug.tags += [jira_issue.key.lower()]
+        bug.lp_save()
 
 def main(args=None):
     opt_parser = argparse.ArgumentParser(
@@ -200,7 +204,7 @@ def main(args=None):
             lp-to-jira -e 3215487 FR
             lp-to-jira -l ubuntu-meeting 3215487 PR
             lp-to-jira -s ubuntu -d 3 IQA
-            lp-to-jira --no-lp-link -c Network -E FS-543 123231 PR
+            lp-to-jira --lp-tag -c Network -E FS-543 123231 PR
             lp-to-jira -s ubuntu -t go-to-jira PR
             lp-to-jira -s ubuntu -t go-to-jira -t also-to-jira PR
             lp-to-jira -s ubuntu -t=-ignore-these PR
@@ -269,11 +273,18 @@ def main(args=None):
             ''')
     )
     opt_parser.add_argument(
-        '--no-lp-link',
-        dest='no_lp_link',
+        '--lp-link',
+        dest='lp_link',
         action='store_true',
-        help='Do not add link in description to LP Bug'
+        help='Add link in description to LP Bug'
     )
+    opt_parser.add_argument(
+        '--lp-tag',
+        dest='lp_tag',
+        action='store_true',
+        help='Add tag to LP Bug'
+    )
+
 
     opts = opt_parser.parse_args(args)
 

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -189,7 +189,7 @@ def lp_to_jira_bug(lp, jira, bug, project_id, opts):
         bug.description += '\n\n---\nExternal link: https://warthogs.atlassian.net/browse/'+jira_issue.key
         bug.lp_save()
 
-    if opts.lp_tag:
+    if not opts.no_lp_tag:
         # Add reference to the JIRA entry in the bugs on Launchpad
         bug.tags += [jira_issue.key.lower()]
         bug.lp_save()
@@ -204,7 +204,7 @@ def main(args=None):
             lp-to-jira -e 3215487 FR
             lp-to-jira -l ubuntu-meeting 3215487 PR
             lp-to-jira -s ubuntu -d 3 IQA
-            lp-to-jira --lp-tag -c Network -E FS-543 123231 PR
+            lp-to-jira --no-lp-tag -c Network -E FS-543 123231 PR
             lp-to-jira -s ubuntu -t go-to-jira PR
             lp-to-jira -s ubuntu -t go-to-jira -t also-to-jira PR
             lp-to-jira -s ubuntu -t=-ignore-these PR
@@ -279,12 +279,11 @@ def main(args=None):
         help='Add link in description to LP Bug'
     )
     opt_parser.add_argument(
-        '--lp-tag',
-        dest='lp_tag',
+        '--no-lp-tag',
+        dest='no_lp_tag',
         action='store_true',
-        help='Add tag to LP Bug'
+        help='Do not add tag to LP Bug'
     )
-
 
     opts = opt_parser.parse_args(args)
 

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -273,10 +273,10 @@ def main(args=None):
             ''')
     )
     opt_parser.add_argument(
-        '--lp-link',
+        '--add-link-in-lp-desc',
         dest='lp_link',
         action='store_true',
-        help='Add link in description to LP Bug'
+        help='Add JIRA link in LP Bug description'
     )
     opt_parser.add_argument(
         '--no-lp-tag',

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ JIRA API token can be created here https://id.atlassian.com/manage-profile/secur
 
 ## Usage:
 ```
-usage: lp-to-jira [-h] [-l LABEL] [-c COMPONENT] [-E EPIC] [-e] [-s SYNC_PROJECT_BUGS] [-d DAYS] [-t TAGS] [--no-lp-link] [bug] project
+usage: lp-to-jira [-h] [-l LABEL] [-c COMPONENT] [-E EPIC] [-e] [-s SYNC_PROJECT_BUGS] [-d DAYS] [-t TAGS] [--lp-link] [--lp-tag] [bug] project
 
 A script create JIRA issue from Launchpad bugs
 
@@ -39,14 +39,15 @@ optional arguments:
   -t TAGS, --tag TAGS
                         Only look for LP Bugs with the specified tag(s). To exclude,
                         prepend a '-', e.g. '-unwantedtag'
-  --no-lp-link          Do not add link in description to LP Bug
+  --lp-tag           Add tag to LP Bug
+  --lp-link          Add link in description to LP Bug
 
 Examples:
     lp-to-jira 3215487 FR
     lp-to-jira -e 3215487 FR
     lp-to-jira -l ubuntu-meeting 3215487 PR
     lp-to-jira -s ubuntu -d 3 IQA
-    lp-to-jira --no-lp-link -c Network -E FS-543 123231 PR
+    lp-to-jira --lp-tag -c Network -E FS-543 123231 PR
     lp-to-jira -s ubuntu -t go-to-jira PR
     lp-to-jira -s ubuntu -t go-to-jira -t also-to-jira PR
     lp-to-jira -s ubuntu -t=-ignore-these PR

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ JIRA API token can be created here https://id.atlassian.com/manage-profile/secur
 
 ## Usage:
 ```
-usage: lp-to-jira [-h] [-l LABEL] [-c COMPONENT] [-E EPIC] [-e] [-s SYNC_PROJECT_BUGS] [-d DAYS] [-t TAGS] [--no-lp-tag] [bug] project
+usage: lp-to-jira [-h] [-l LABEL] [-c COMPONENT] [-E EPIC] [-e] [-s SYNC_PROJECT_BUGS] [-d DAYS] [-t TAGS] [--no-lp-link] [bug] project
 
 A script create JIRA issue from Launchpad bugs
 
@@ -39,14 +39,14 @@ optional arguments:
   -t TAGS, --tag TAGS
                         Only look for LP Bugs with the specified tag(s). To exclude,
                         prepend a '-', e.g. '-unwantedtag'
-  --no-lp-tag           Do not add tag to LP Bug
+  --no-lp-link          Do not add link in description to LP Bug
 
 Examples:
     lp-to-jira 3215487 FR
     lp-to-jira -e 3215487 FR
     lp-to-jira -l ubuntu-meeting 3215487 PR
     lp-to-jira -s ubuntu -d 3 IQA
-    lp-to-jira --no-lp-tag -c Network -E FS-543 123231 PR
+    lp-to-jira --no-lp-link -c Network -E FS-543 123231 PR
     lp-to-jira -s ubuntu -t go-to-jira PR
     lp-to-jira -s ubuntu -t go-to-jira -t also-to-jira PR
     lp-to-jira -s ubuntu -t=-ignore-these PR

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ JIRA API token can be created here https://id.atlassian.com/manage-profile/secur
 
 ## Usage:
 ```
-usage: lp-to-jira [-h] [-l LABEL] [-c COMPONENT] [-E EPIC] [-e] [-s SYNC_PROJECT_BUGS] [-d DAYS] [-t TAGS] [--lp-link] [--no-lp-tag] [bug] project
+usage: lp-to-jira [-h] [-l LABEL] [-c COMPONENT] [-E EPIC] [-e] [-s SYNC_PROJECT_BUGS] [-d DAYS] [-t TAGS] [--add-link-in-lp-desc ] [--no-lp-tag] [bug] project
 
 A script create JIRA issue from Launchpad bugs
 
@@ -40,7 +40,8 @@ optional arguments:
                         Only look for LP Bugs with the specified tag(s). To exclude,
                         prepend a '-', e.g. '-unwantedtag'
   --no-lp-tag           Do not add tag to LP Bug
-  --lp-link          Add link in description to LP Bug
+  --add-link-in-lp-desc
+                        Add JIRA link in LP Bug description
 
 Examples:
     lp-to-jira 3215487 FR

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ JIRA API token can be created here https://id.atlassian.com/manage-profile/secur
 
 ## Usage:
 ```
-usage: lp-to-jira [-h] [-l LABEL] [-c COMPONENT] [-E EPIC] [-e] [-s SYNC_PROJECT_BUGS] [-d DAYS] [-t TAGS] [--lp-link] [--lp-tag] [bug] project
+usage: lp-to-jira [-h] [-l LABEL] [-c COMPONENT] [-E EPIC] [-e] [-s SYNC_PROJECT_BUGS] [-d DAYS] [-t TAGS] [--lp-link] [--no-lp-tag] [bug] project
 
 A script create JIRA issue from Launchpad bugs
 
@@ -39,7 +39,7 @@ optional arguments:
   -t TAGS, --tag TAGS
                         Only look for LP Bugs with the specified tag(s). To exclude,
                         prepend a '-', e.g. '-unwantedtag'
-  --lp-tag           Add tag to LP Bug
+  --no-lp-tag           Do not add tag to LP Bug
   --lp-link          Add link in description to LP Bug
 
 Examples:
@@ -47,7 +47,7 @@ Examples:
     lp-to-jira -e 3215487 FR
     lp-to-jira -l ubuntu-meeting 3215487 PR
     lp-to-jira -s ubuntu -d 3 IQA
-    lp-to-jira --lp-tag -c Network -E FS-543 123231 PR
+    lp-to-jira --no-lp-tag -c Network -E FS-543 123231 PR
     lp-to-jira -s ubuntu -t go-to-jira PR
     lp-to-jira -s ubuntu -t go-to-jira -t also-to-jira PR
     lp-to-jira -s ubuntu -t=-ignore-these PR


### PR DESCRIPTION
When you add the weblink manually in JIRA. It will automatically add the Launchpad favicon, which makes the link very visible to user. I am suggesting we do the same in the script