### PR TITLE
Attach full JIRA link insteads of issue key as tag in LP

### DIFF
--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -184,9 +184,9 @@ def lp_to_jira_bug(lp, jira, bug, project_id, opts):
 
     jira_issue = create_jira_issue(jira, issue_dict, bug, opts)
 
-    if not opts.no_lp_tag:
+    if not opts.no_lp_link:
         # Add reference to the JIRA entry in the bugs on Launchpad
-        bug.tags += [jira_issue.key.lower()]
+        bug.description += '\n\n---\nExternal link: https://warthogs.atlassian.net/browse/'+jira_issue.key
         bug.lp_save()
 
 
@@ -200,7 +200,7 @@ def main(args=None):
             lp-to-jira -e 3215487 FR
             lp-to-jira -l ubuntu-meeting 3215487 PR
             lp-to-jira -s ubuntu -d 3 IQA
-            lp-to-jira --no-lp-tag -c Network -E FS-543 123231 PR
+            lp-to-jira --no-lp-link -c Network -E FS-543 123231 PR
             lp-to-jira -s ubuntu -t go-to-jira PR
             lp-to-jira -s ubuntu -t go-to-jira -t also-to-jira PR
             lp-to-jira -s ubuntu -t=-ignore-these PR
@@ -269,10 +269,10 @@ def main(args=None):
             ''')
     )
     opt_parser.add_argument(
-        '--no-lp-tag',
-        dest='no_lp_tag',
+        '--no-lp-link',
+        dest='no_lp_link',
         action='store_true',
-        help='Do not add tag to LP Bug'
+        help='Do not add link in description to LP Bug'
     )
 
     opts = opt_parser.parse_args(args)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ JIRA API token can be created here https://id.atlassian.com/manage-profile/secur
 
 ## Usage:
 ```
-usage: lp-to-jira [-h] [-l LABEL] [-c COMPONENT] [-E EPIC] [-e] [-s SYNC_PROJECT_BUGS] [-d DAYS] [-t TAGS] [--no-lp-tag] [bug] project
+usage: lp-to-jira [-h] [-l LABEL] [-c COMPONENT] [-E EPIC] [-e] [-s SYNC_PROJECT_BUGS] [-d DAYS] [-t TAGS] [--no-lp-link] [bug] project
 
 A script create JIRA issue from Launchpad bugs
 
@@ -39,14 +39,14 @@ optional arguments:
   -t TAGS, --tag TAGS
                         Only look for LP Bugs with the specified tag(s). To exclude,
                         prepend a '-', e.g. '-unwantedtag'
-  --no-lp-tag           Do not add tag to LP Bug
+  --no-lp-link          Do not add link in description to LP Bug
 
 Examples:
     lp-to-jira 3215487 FR
     lp-to-jira -e 3215487 FR
     lp-to-jira -l ubuntu-meeting 3215487 PR
     lp-to-jira -s ubuntu -d 3 IQA
-    lp-to-jira --no-lp-tag -c Network -E FS-543 123231 PR
+    lp-to-jira --no-lp-link -c Network -E FS-543 123231 PR
     lp-to-jira -s ubuntu -t go-to-jira PR
     lp-to-jira -s ubuntu -t go-to-jira -t also-to-jira PR
     lp-to-jira -s ubuntu -t=-ignore-these PR


### PR DESCRIPTION
The original behaviour is to attach the JIRA issue key as a tag in LP. However, it isn't really useful since LP bug and JIRA are 1-to-1 in most of the cases. So the tag in LP isn't useful as a filter/grouping perspective. And if you want to navigate from LP to Jira, you will then need to copy the JIRA key, and type the JIRA url yourself.

So instead of using tag. I would suggest to just append the full url at the end of the description. In that case, user can just navigate back to JIRA with a single click, where the user can also do the same in the JIRA weblink