### PR TITLE
Do not include JIRA components argument when it is empty

### DIFF
--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -141,10 +141,15 @@ def build_jira_issue(lp, bug, project_id, opts=None):
     if opts and opts.component:
         jira_component = [{"name": opts.component}]
     else:
-        jira_component = [
-            {"name": pkg_to_component.get(bug_pkg)}
-        ]
-    issue_dict["components"] = jira_component
+        if pkg_to_component.get(bug_pkg) != None:
+            jira_component = [
+                {"name": pkg_to_component.get(bug_pkg)}
+            ]
+        else:
+            jira_component = None
+
+    if jira_component != None:
+        issue_dict["components"] = jira_component
 
     return issue_dict
 


### PR DESCRIPTION
There is error when importing LP bug to JIRA recently. The error is:
Traceback (most recent call last):
  File "/snap/lp-to-jira/x1/bin/lp-to-jira", line 8, in <module>
    sys.exit(main())
  File "/snap/lp-to-jira/x1/lib/python3.8/site-packages/LpToJira/lp_to_jira.py", line 334, in main
    lp_to_jira_bug(lp, jira, bug, project_id, opts)
  File "/snap/lp-to-jira/x1/lib/python3.8/site-packages/LpToJira/lp_to_jira.py", line 185, in lp_to_jira_bug
    jira_issue = create_jira_issue(jira, issue_dict, bug, opts)
  File "/snap/lp-to-jira/x1/lib/python3.8/site-packages/LpToJira/lp_to_jira.py", line 156, in create_jira_issue
    new_issue = jira.create_issue(fields=issue_dict)
  File "/snap/lp-to-jira/x1/lib/python3.8/site-packages/jira/client.py", line 1315, in create_issue
    r = self._session.post(url, data=json.dumps(data))
  File "/snap/lp-to-jira/x1/lib/python3.8/site-packages/jira/resilientsession.py", line 175, in post
    return self.verb("POST", url, **kwargs)
  File "/snap/lp-to-jira/x1/lib/python3.8/site-packages/jira/resilientsession.py", line 168, in verb
    raise_on_error(response, verb=verb, *kwargs)
  File "/snap/lp-to-jira/x1/lib/python3.8/site-packages/jira/resilientsession.py", line 53, in raise_on_error
    raise JIRAError(
jira.exceptions.JIRAError: JiraError HTTP 400 url: https://warthogs.atlassian.net/rest/api/2/issue
    text: Could not find valid 'id' or 'name' in component object.


After reviewing the code, it seems that it will add the component argument even if there is no matching component to assign. So I fixed by not inserting the component to the dict.

I have tested my fix in a normal case where there is no matching component but I can't find a relevant LP bug to test on the other path
