### PR TITLE
feat: Update Jira python library for new server API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 packages = find:
 install_requires =
     launchpadlib
-    jira
+    jira>=3.10.5
 
 [options.extras_require]
 test =

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: lp-to-jira
-base: core20
-version: '0.7'
+base: core24
+version: '0.8'
 summary: Command Line Interface to import Launchpad content into JIRA
 description: |
   lp-to-jira allows you to import bug from a launchpad project into a JIRA

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,3 +1,4 @@
+title: LaunchPad to Jira Bug Importer
 name: lp-to-jira
 base: core24
 version: '0.8'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ parts:
     stage-packages:
       - python3-wheel
     python-packages:
-      - jira == 3.0.1
+      - jira
       - launchpadlib
     source: .
 


### PR DESCRIPTION
Atlassian updated the Jira cloud API to search for issues causing lp-to-jira to fail
By forcing the setup.cfg to jira 3.10.5 or newer it resolves the problem. it is then not necessary to specific another jira version in the snapcraft.yaml